### PR TITLE
Inject every models variations and DB model in DB adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Add quickly a registration and authentication system to your [FastAPI](https://f
 * [X] Customizable database backend
     * [X] SQLAlchemy async backend included thanks to [encode/databases](https://www.encode.io/databases/)
     * [X] MongoDB async backend included thanks to [mongodb/motor](https://github.com/mongodb/motor)
+    * [X] [Tortoise ORM](https://tortoise-orm.readthedocs.io/en/latest/) backend included
 * [X] Multiple customizable authentication backends
     * [X] JWT authentication backend included
     * [X] Cookie authentication backend included

--- a/docs/configuration/databases/mongodb.md
+++ b/docs/configuration/databases/mongodb.md
@@ -6,7 +6,7 @@
 
 Let's create a MongoDB connection and instantiate a collection.
 
-```py hl_lines="5 6 7 8"
+```py hl_lines="23 24 25 26"
 {!./src/db_mongodb.py!}
 ```
 
@@ -16,9 +16,11 @@ You can choose any name for the database and the collection.
 
 The database adapter of **FastAPI Users** makes the link between your database configuration and the users logic. Create it like this.
 
-```py hl_lines="14"
+```py hl_lines="32"
 {!./src/db_mongodb.py!}
 ```
+
+Notice that we pass a reference to your [`UserDB` model](../model.md).
 
 !!! info
     The database adapter will automatically create a [unique index](https://docs.mongodb.com/manual/core/index-unique/) on `id` and `email`.

--- a/docs/configuration/databases/sqlalchemy.md
+++ b/docs/configuration/databases/sqlalchemy.md
@@ -24,7 +24,7 @@ For the sake of this tutorial from now on, we'll use a simple SQLite databse.
 
 Let's create a `metadata` object and declare our User table.
 
-```py hl_lines="4 14 15"
+```py hl_lines="5 32 33"
 {!./src/db_sqlalchemy.py!}
 ```
 
@@ -34,7 +34,7 @@ As you can see, **FastAPI Users** provides a mixin that will include base fields
 
 We'll now create an SQLAlchemy enigne and ask it to create all the defined tables.
 
-```py hl_lines="18 19 20 21 22"
+```py hl_lines="36 37 38 39 40"
 {!./src/db_sqlalchemy.py!}
 ```
 
@@ -45,11 +45,15 @@ We'll now create an SQLAlchemy enigne and ask it to create all the defined table
 
 The database adapter of **FastAPI Users** makes the link between your database configuration and the users logic. Create it like this.
 
-```py hl_lines="24 25"
+```py hl_lines="42 43"
 {!./src/db_sqlalchemy.py!}
 ```
 
-Notice that we declare the `users` variable, which is the actual SQLAlchemy table behind the table class. We also use our `database` instance, which allows us to do asynchronous request to the database.
+Notice that we pass it three things:
+
+* A reference to your [`UserDB` model](../model.md).
+* The `users` variable, which is the actual SQLAlchemy table behind the table class.
+* A `database` instance, which allows us to do asynchronous request to the database.
 
 ## Next steps
 

--- a/docs/configuration/databases/tortoise.md
+++ b/docs/configuration/databases/tortoise.md
@@ -22,21 +22,23 @@ For the sake of this tutorial from now on, we'll use a simple SQLite databse.
 
 ## Setup User table
 
-Let's declare our User model.
+Let's declare our User ORM model.
 
-```py hl_lines="9 10"
+```py hl_lines="26 27"
 {!./src/db_tortoise.py!}
 ```
 
-As you can see, **FastAPI Users** provides a mixin that will include base fields for our User table. You can of course add you own fields there to fit to your needs!
+As you can see, **FastAPI Users** provides an abstract model that will include base fields for our User table. You can of course add you own fields there to fit to your needs!
 
 ## Create the database adapter
 
 The database adapter of **FastAPI Users** makes the link between your database configuration and the users logic. Create it like this.
 
-```py hl_lines="13"
+```py hl_lines="30"
 {!./src/db_tortoise.py!}
 ```
+
+Notice that we pass a reference to your [`UserDB` model](../model.md).
 
 ## Register Tortoise
 
@@ -44,7 +46,7 @@ For using Tortoise ORM we must register our models and database.
 
 Tortoise ORM supports integration with Starlette/FastAPI out-of-the-box. It will automatically bind startup and shutdown events.
 
-```py hl_lines="16"
+```py hl_lines="33"
 {!./src/db_tortoise.py!}
 ```
 

--- a/docs/configuration/model.md
+++ b/docs/configuration/model.md
@@ -7,15 +7,34 @@
 * `is_active` (`bool`) – Whether or not the user is active. If not, login and forgot password requests will be denied. Default to `True`.
 * `is_active` (`bool`) – Whether or not the user is a superuser. Useful to implement administration logic. Default to `False`.
 
-## Use the model
+## Define your models
 
-The model is exposed as a Pydantic model mixin.
+There are four Pydantic models variations provided as mixins:
+
+* `BaseUser`, which provides the basic fields and validation ;
+* `BaseCreateUser`, dedicated to user registration, which makes the `email` compulsory and adds a compulsory `password` field ;
+* `BaseUpdateUser`, dedicated to user profile update, which adds an optional `password` field ;
+* `BaseUserDB`, which is a representation of the user in database, adding a `hashed_password` field.
+
+You should define each of those variations, inheriting from each mixin:
 
 ```py
-from fastapi_users import BaseUser
+from fastapi_users import models
 
 
-class User(BaseUser):
+class User(models.BaseUser):
+    pass
+
+
+class UserCreate(User, models.BaseUserCreate):
+    pass
+
+
+class UserUpdate(User, models.BaseUserUpdate):
+    pass
+
+
+class UserDB(User, models.BaseUserDB):
     pass
 ```
 

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -1,6 +1,6 @@
 # Router
 
-We're almost there! The last step is to configure the `FastAPIUsers` object that will wire the database adapter, the authentication class and the user model to expose the FastAPI router.
+We're almost there! The last step is to configure the `FastAPIUsers` object that will wire the database adapter, the authentication class and the user models to expose the FastAPI router.
 
 ## Configure `FastAPIUsers`
 
@@ -9,6 +9,9 @@ Configure `FastAPIUsers` object with all the elements we defined before. More pr
 * `db`: Database adapter instance.
 * `auth_backends`: List of authentication backends. See [Authentication](./authentication/index.md).
 * `user_model`: Pydantic model of a user.
+* `user_create_model`: Pydantic model for creating a user.
+* `user_update_model`: Pydantic model for updating a user.
+* `user_db_model`: Pydantic model of a DB representation of a user.
 * `reset_password_token_secret`: Secret to encode reset password token.
 * `reset_password_token_lifetime_seconds`: Lifetime of reset password token in seconds. Default to one hour.
 
@@ -19,6 +22,9 @@ fastapi_users = FastAPIUsers(
     user_db,
     auth_backends,
     User,
+    UserCreate,
+    UserUpdate,
+    UserDB,
     SECRET,
 )
 ```

--- a/docs/src/db_mongodb.py
+++ b/docs/src/db_mongodb.py
@@ -1,6 +1,24 @@
 import motor.motor_asyncio
 from fastapi import FastAPI
+from fastapi_users import models
 from fastapi_users.db import MongoDBUserDatabase
+
+
+class User(models.BaseUser):
+    pass
+
+
+class UserCreate(User, models.BaseUserCreate):
+    pass
+
+
+class UserUpdate(User, models.BaseUserUpdate):
+    pass
+
+
+class UserDB(User, models.BaseUserDB):
+    pass
+
 
 DATABASE_URL = "mongodb://localhost:27017"
 client = motor.motor_asyncio.AsyncIOMotorClient(DATABASE_URL)
@@ -11,4 +29,4 @@ collection = db["users"]
 app = FastAPI()
 
 
-user_db = MongoDBUserDatabase(collection)
+user_db = MongoDBUserDatabase(UserDB, collection)

--- a/docs/src/db_sqlalchemy.py
+++ b/docs/src/db_sqlalchemy.py
@@ -1,8 +1,26 @@
 import databases
 import sqlalchemy
 from fastapi import FastAPI
+from fastapi_users import models
 from fastapi_users.db import SQLAlchemyBaseUserTable, SQLAlchemyUserDatabase
 from sqlalchemy.ext.declarative import DeclarativeMeta, declarative_base
+
+
+class User(models.BaseUser):
+    pass
+
+
+class UserCreate(User, models.BaseUserCreate):
+    pass
+
+
+class UserUpdate(User, models.BaseUserUpdate):
+    pass
+
+
+class UserDB(User, models.BaseUserDB):
+    pass
+
 
 DATABASE_URL = "sqlite:///./test.db"
 
@@ -22,7 +40,7 @@ engine = sqlalchemy.create_engine(
 Base.metadata.create_all(engine)
 
 users = UserTable.__table__
-user_db = SQLAlchemyUserDatabase(database, users)
+user_db = SQLAlchemyUserDatabase(UserDB, database, users)
 
 app = FastAPI()
 

--- a/docs/src/db_tortoise.py
+++ b/docs/src/db_tortoise.py
@@ -1,16 +1,33 @@
 from fastapi import FastAPI
-from fastapi_users.db.tortoise import BaseUserModel, TortoiseUserDatabase
-from tortoise import Model
+from fastapi_users import models
+from fastapi_users.db import TortoiseBaseUserModel, TortoiseUserDatabase
 from tortoise.contrib.starlette import register_tortoise
+
+
+class User(models.BaseUser):
+    pass
+
+
+class UserCreate(User, models.BaseUserCreate):
+    pass
+
+
+class UserUpdate(User, models.BaseUserUpdate):
+    pass
+
+
+class UserDB(User, models.BaseUserDB):
+    pass
+
 
 DATABASE_URL = "sqlite://./test.db"
 
 
-class UserModel(BaseUserModel, Model):
+class UserModel(TortoiseBaseUserModel):
     pass
 
 
-user_db = TortoiseUserDatabase(UserModel)
+user_db = TortoiseUserDatabase(UserDB, UserModel)
 app = FastAPI()
 
 register_tortoise(app, modules={"models": ["path_to_your_package"]})

--- a/docs/src/full_mongodb.py
+++ b/docs/src/full_mongodb.py
@@ -1,6 +1,6 @@
 import motor.motor_asyncio
 from fastapi import FastAPI
-from fastapi_users import BaseUser, FastAPIUsers
+from fastapi_users import FastAPIUsers, models
 from fastapi_users.authentication import JWTAuthentication
 from fastapi_users.db import MongoDBUserDatabase
 
@@ -8,24 +8,35 @@ DATABASE_URL = "mongodb://localhost:27017"
 SECRET = "SECRET"
 
 
+class User(models.BaseUser):
+    pass
+
+
+class UserCreate(User, models.BaseUserCreate):
+    pass
+
+
+class UserUpdate(User, models.BaseUserUpdate):
+    pass
+
+
+class UserDB(User, models.BaseUserDB):
+    pass
+
+
 client = motor.motor_asyncio.AsyncIOMotorClient(DATABASE_URL)
 db = client["database_name"]
 collection = db["users"]
-
-
-user_db = MongoDBUserDatabase(collection)
-
-
-class User(BaseUser):
-    pass
-
+user_db = MongoDBUserDatabase(UserDB, collection)
 
 auth_backends = [
     JWTAuthentication(secret=SECRET, lifetime_seconds=3600),
 ]
 
 app = FastAPI()
-fastapi_users = FastAPIUsers(user_db, auth_backends, User, SECRET)
+fastapi_users = FastAPIUsers(
+    user_db, auth_backends, User, UserCreate, UserUpdate, UserDB, SECRET,
+)
 app.include_router(fastapi_users.router, prefix="/users", tags=["users"])
 
 

--- a/fastapi_users/__init__.py
+++ b/fastapi_users/__init__.py
@@ -2,5 +2,5 @@
 
 __version__ = "0.4.1"
 
+from fastapi_users import models  # noqa: F401
 from fastapi_users.fastapi_users import FastAPIUsers  # noqa: F401
-from fastapi_users.models import BaseUser  # noqa: F401

--- a/fastapi_users/db/__init__.py
+++ b/fastapi_users/db/__init__.py
@@ -12,3 +12,11 @@ try:
     )
 except ImportError:  # pragma: no cover
     pass
+
+try:
+    from fastapi_users.db.tortoise import (  # noqa: F401
+        TortoiseBaseUserModel,
+        TortoiseUserDatabase,
+    )
+except ImportError:  # pragma: no cover
+    pass

--- a/fastapi_users/db/base.py
+++ b/fastapi_users/db/base.py
@@ -1,41 +1,50 @@
-from typing import List, Optional
+from typing import Generic, List, Optional, Type
 
 from fastapi.security import OAuth2PasswordRequestForm
 
 from fastapi_users import password
-from fastapi_users.models import BaseUserDB
+from fastapi_users.models import UD
 
 
-class BaseUserDatabase:
-    """Base adapter for retrieving, creating and updating users from a database."""
+class BaseUserDatabase(Generic[UD]):
+    """
+    Base adapter for retrieving, creating and updating users from a database.
 
-    async def list(self) -> List[BaseUserDB]:
+    :param user_db_model: Pydantic model of a DB representation of a user.
+    """
+
+    user_db_model: Type[UD]
+
+    def __init__(self, user_db_model: Type[UD]):
+        self.user_db_model = user_db_model
+
+    async def list(self) -> List[UD]:
         """List all users."""
         raise NotImplementedError()
 
-    async def get(self, id: str) -> Optional[BaseUserDB]:
+    async def get(self, id: str) -> Optional[UD]:
         """Get a single user by id."""
         raise NotImplementedError()
 
-    async def get_by_email(self, email: str) -> Optional[BaseUserDB]:
+    async def get_by_email(self, email: str) -> Optional[UD]:
         """Get a single user by email."""
         raise NotImplementedError()
 
-    async def create(self, user: BaseUserDB) -> BaseUserDB:
+    async def create(self, user: UD) -> UD:
         """Create a user."""
         raise NotImplementedError()
 
-    async def update(self, user: BaseUserDB) -> BaseUserDB:
+    async def update(self, user: UD) -> UD:
         """Update a user."""
         raise NotImplementedError()
 
-    async def delete(self, user: BaseUserDB) -> None:
+    async def delete(self, user: UD) -> None:
         """Delete a user."""
         raise NotImplementedError()
 
     async def authenticate(
         self, credentials: OAuth2PasswordRequestForm
-    ) -> Optional[BaseUserDB]:
+    ) -> Optional[UD]:
         """
         Authenticate and return a user following an email and a password.
 

--- a/fastapi_users/db/mongodb.py
+++ b/fastapi_users/db/mongodb.py
@@ -1,43 +1,45 @@
-from typing import List, Optional
+from typing import List, Optional, Type
 
 from motor.motor_asyncio import AsyncIOMotorCollection
 
 from fastapi_users.db.base import BaseUserDatabase
-from fastapi_users.models import BaseUserDB
+from fastapi_users.models import UD
 
 
-class MongoDBUserDatabase(BaseUserDatabase):
+class MongoDBUserDatabase(BaseUserDatabase[UD]):
     """
     Database adapter for MongoDB.
 
+    :param user_db_model: Pydantic model of a DB representation of a user.
     :param collection: Collection instance from `motor`.
     """
 
     collection: AsyncIOMotorCollection
 
-    def __init__(self, collection: AsyncIOMotorCollection):
+    def __init__(self, user_db_model: Type[UD], collection: AsyncIOMotorCollection):
+        super().__init__(user_db_model)
         self.collection = collection
         self.collection.create_index("id", unique=True)
         self.collection.create_index("email", unique=True)
 
-    async def list(self) -> List[BaseUserDB]:
-        return [BaseUserDB(**user) async for user in self.collection.find()]
+    async def list(self) -> List[UD]:
+        return [self.user_db_model(**user) async for user in self.collection.find()]
 
-    async def get(self, id: str) -> Optional[BaseUserDB]:
+    async def get(self, id: str) -> Optional[UD]:
         user = await self.collection.find_one({"id": id})
-        return BaseUserDB(**user) if user else None
+        return self.user_db_model(**user) if user else None
 
-    async def get_by_email(self, email: str) -> Optional[BaseUserDB]:
+    async def get_by_email(self, email: str) -> Optional[UD]:
         user = await self.collection.find_one({"email": email})
-        return BaseUserDB(**user) if user else None
+        return self.user_db_model(**user) if user else None
 
-    async def create(self, user: BaseUserDB) -> BaseUserDB:
+    async def create(self, user: UD) -> UD:
         await self.collection.insert_one(user.dict())
         return user
 
-    async def update(self, user: BaseUserDB) -> BaseUserDB:
+    async def update(self, user: UD) -> UD:
         await self.collection.replace_one({"id": user.id}, user.dict())
         return user
 
-    async def delete(self, user: BaseUserDB) -> None:
+    async def delete(self, user: UD) -> None:
         await self.collection.delete_one({"id": user.id})

--- a/fastapi_users/db/tortoise.py
+++ b/fastapi_users/db/tortoise.py
@@ -7,7 +7,7 @@ from fastapi_users.db.base import BaseUserDatabase
 from fastapi_users.models import UD
 
 
-class BaseUserModel(Model):
+class TortoiseBaseUserModel(Model):
     id = fields.CharField(pk=True, generated=False, max_length=255)
     email = fields.CharField(index=True, unique=True, null=False, max_length=255)
     hashed_password = fields.CharField(null=False, max_length=255)
@@ -26,9 +26,9 @@ class TortoiseUserDatabase(BaseUserDatabase[UD]):
     :param model: Tortoise ORM model.
     """
 
-    model: Type[BaseUserModel]
+    model: Type[TortoiseBaseUserModel]
 
-    def __init__(self, user_db_model: Type[UD], model: Type[BaseUserModel]):
+    def __init__(self, user_db_model: Type[UD], model: Type[TortoiseBaseUserModel]):
         super().__init__(user_db_model)
         self.model = model
 

--- a/fastapi_users/db/tortoise.py
+++ b/fastapi_users/db/tortoise.py
@@ -3,11 +3,11 @@ from typing import List, Optional, Type
 from tortoise import Model, fields
 from tortoise.exceptions import DoesNotExist
 
-from fastapi_users.db import BaseUserDatabase
-from fastapi_users.models import BaseUserDB
+from fastapi_users.db.base import BaseUserDatabase
+from fastapi_users.models import UD
 
 
-class BaseUserModel:
+class BaseUserModel(Model):
     id = fields.CharField(pk=True, generated=False, max_length=255)
     email = fields.CharField(index=True, unique=True, null=False, max_length=255)
     hashed_password = fields.CharField(null=False, max_length=255)
@@ -15,44 +15,51 @@ class BaseUserModel:
     is_superuser = fields.BooleanField(default=False, null=False)
 
     class Meta:
-        table = "user"
+        abstract = True
 
 
-class TortoiseUserDatabase(BaseUserDatabase):
+class TortoiseUserDatabase(BaseUserDatabase[UD]):
+    """
+    Database adapter for Tortoise ORM.
 
-    model: Type[Model]
+    :param user_db_model: Pydantic model of a DB representation of a user.
+    :param model: Tortoise ORM model.
+    """
 
-    def __init__(self, model: Type[Model]):
+    model: Type[BaseUserModel]
+
+    def __init__(self, user_db_model: Type[UD], model: Type[BaseUserModel]):
+        super().__init__(user_db_model)
         self.model = model
 
-    async def list(self) -> List[BaseUserDB]:
+    async def list(self) -> List[UD]:
         users = await self.model.all()
-        return [BaseUserDB.from_orm(user) for user in users]
+        return [self.user_db_model.from_orm(user) for user in users]
 
-    async def get(self, id: str) -> Optional[BaseUserDB]:
+    async def get(self, id: str) -> Optional[UD]:
         try:
             user = await self.model.get(id=id)
-            return BaseUserDB.from_orm(user)
+            return self.user_db_model.from_orm(user)
         except DoesNotExist:
             return None
 
-    async def get_by_email(self, email: str) -> Optional[BaseUserDB]:
+    async def get_by_email(self, email: str) -> Optional[UD]:
         try:
             user = await self.model.get(email=email)
-            return BaseUserDB.from_orm(user)
+            return self.user_db_model.from_orm(user)
         except DoesNotExist:
             return None
 
-    async def create(self, user: BaseUserDB) -> BaseUserDB:
+    async def create(self, user: UD) -> UD:
         model = self.model(**user.dict())
         await model.save()
         return user
 
-    async def update(self, user: BaseUserDB) -> BaseUserDB:
+    async def update(self, user: UD) -> UD:
         user_dict = user.dict()
         user_dict.pop("id")  # Tortoise complains if we pass the PK again
         await self.model.filter(id=user.id).update(**user_dict)
         return user
 
-    async def delete(self, user: BaseUserDB) -> None:
+    async def delete(self, user: UD) -> None:
         await self.model.filter(id=user.id).delete()

--- a/fastapi_users/fastapi_users.py
+++ b/fastapi_users/fastapi_users.py
@@ -1,8 +1,8 @@
 from typing import Callable, Sequence, Type
 
+from fastapi_users import models
 from fastapi_users.authentication import Authenticator, BaseAuthentication
 from fastapi_users.db import BaseUserDatabase
-from fastapi_users.models import BaseUser
 from fastapi_users.router import Event, UserRouter, get_user_router
 
 
@@ -13,6 +13,9 @@ class FastAPIUsers:
     :param db: Database adapter instance.
     :param auth_backends: List of authentication backends.
     :param user_model: Pydantic model of a user.
+    :param user_create_model: Pydantic model for creating a user.
+    :param user_update_model: Pydantic model for updating a user.
+    :param user_db_model: Pydantic model of a DB representation of a user.
     :param reset_password_token_secret: Secret to encode reset password token.
     :param reset_password_token_lifetime_seconds: Lifetime of reset password token.
 
@@ -28,7 +31,10 @@ class FastAPIUsers:
         self,
         db: BaseUserDatabase,
         auth_backends: Sequence[BaseAuthentication],
-        user_model: Type[BaseUser],
+        user_model: Type[models.BaseUser],
+        user_create_model: Type[models.BaseUserCreate],
+        user_update_model: Type[models.BaseUserUpdate],
+        user_db_model: Type[models.BaseUserDB],
         reset_password_token_secret: str,
         reset_password_token_lifetime_seconds: int = 3600,
     ):
@@ -37,6 +43,9 @@ class FastAPIUsers:
         self.router = get_user_router(
             self.db,
             user_model,
+            user_create_model,
+            user_update_model,
+            user_db_model,
             self.authenticator,
             reset_password_token_secret,
             reset_password_token_lifetime_seconds,

--- a/fastapi_users/models.py
+++ b/fastapi_users/models.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Optional, Type
+from typing import Optional, TypeVar
 
 import pydantic
 from pydantic import BaseModel, EmailStr
@@ -25,9 +25,6 @@ class BaseUser(BaseModel):
     def create_update_dict_superuser(self):
         return self.dict(exclude_unset=True, exclude={"id"})
 
-    class Config:
-        orm_mode = True
-
 
 class BaseUserCreate(BaseUser):
     email: EmailStr
@@ -39,23 +36,11 @@ class BaseUserUpdate(BaseUser):
 
 
 class BaseUserDB(BaseUser):
+    id: str
     hashed_password: str
 
+    class Config:
+        orm_mode = True
 
-class Models:
-    """Generate models inheriting from the custom User model."""
 
-    def __init__(self, user_model: Type[BaseUser]):
-        class UserCreate(user_model, BaseUserCreate):  # type: ignore
-            pass
-
-        class UserUpdate(user_model, BaseUserUpdate):  # type: ignore
-            pass
-
-        class UserDB(user_model, BaseUserDB):  # type: ignore
-            pass
-
-        self.User = user_model
-        self.UserCreate = UserCreate
-        self.UserUpdate = UserUpdate
-        self.UserDB = UserDB
+UD = TypeVar("UD", bound=BaseUserDB)

--- a/fastapi_users/router.py
+++ b/fastapi_users/router.py
@@ -186,21 +186,29 @@ def get_user_router(
         updated_user_data = updated_user.create_update_dict()
         return await _update_user(user, updated_user_data)
 
-    @router.get("/", response_model=List[user_model])  # type: ignore
-    async def list_users(superuser=Depends(get_current_superuser),):
+    @router.get(
+        "/",
+        response_model=List[user_model],  # type: ignore
+        dependencies=[Depends(get_current_superuser)],
+    )
+    async def list_users():
         return await user_db.list()
 
-    @router.get("/{id}", response_model=user_model)
-    async def get_user(
-        id: str, superuser=Depends(get_current_superuser),
-    ):
+    @router.get(
+        "/{id}",
+        response_model=user_model,
+        dependencies=[Depends(get_current_superuser)],
+    )
+    async def get_user(id: str,):
         return await _get_or_404(id)
 
-    @router.patch("/{id}", response_model=user_model)
+    @router.patch(
+        "/{id}",
+        response_model=user_model,
+        dependencies=[Depends(get_current_superuser)],
+    )
     async def update_user(
-        id: str,
-        updated_user: user_update_model,  # type: ignore
-        superuser=Depends(get_current_superuser),
+        id: str, updated_user: user_update_model,  # type: ignore
     ):
         updated_user = cast(
             models.BaseUserUpdate, updated_user,
@@ -209,10 +217,12 @@ def get_user_router(
         updated_user_data = updated_user.create_update_dict_superuser()
         return await _update_user(user, updated_user_data)
 
-    @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
-    async def delete_user(
-        id: str, superuser=Depends(get_current_superuser),
-    ):
+    @router.delete(
+        "/{id}",
+        status_code=status.HTTP_204_NO_CONTENT,
+        dependencies=[Depends(get_current_superuser)],
+    )
+    async def delete_user(id: str):
         user = await _get_or_404(id)
         await user_db.delete(user)
         return None

--- a/fastapi_users/router.py
+++ b/fastapi_users/router.py
@@ -1,7 +1,7 @@
 import asyncio
-import typing
 from collections import defaultdict
 from enum import Enum, auto
+from typing import Any, Callable, DefaultDict, Dict, List, Type, cast
 
 import jwt
 from fastapi import APIRouter, Body, Depends, HTTPException
@@ -10,9 +10,9 @@ from pydantic import EmailStr
 from starlette import status
 from starlette.responses import Response
 
+from fastapi_users import models
 from fastapi_users.authentication import Authenticator, BaseAuthentication
 from fastapi_users.db import BaseUserDatabase
-from fastapi_users.models import BaseUser, Models
 from fastapi_users.password import get_password_hash
 from fastapi_users.utils import JWT_ALGORITHM, generate_jwt
 
@@ -29,13 +29,13 @@ class Event(Enum):
 
 
 class UserRouter(APIRouter):
-    event_handlers: typing.DefaultDict[Event, typing.List[typing.Callable]]
+    event_handlers: DefaultDict[Event, List[Callable]]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.event_handlers = defaultdict(list)
 
-    def add_event_handler(self, event_type: Event, func: typing.Callable) -> None:
+    def add_event_handler(self, event_type: Event, func: Callable) -> None:
         self.event_handlers[event_type].append(func)
 
     async def run_handlers(self, event_type: Event, *args, **kwargs) -> None:
@@ -65,30 +65,30 @@ def _add_login_route(
 
 
 def get_user_router(
-    user_db: BaseUserDatabase,
-    user_model: typing.Type[BaseUser],
+    user_db: BaseUserDatabase[models.BaseUserDB],
+    user_model: Type[models.BaseUser],
+    user_create_model: Type[models.BaseUserCreate],
+    user_update_model: Type[models.BaseUserUpdate],
+    user_db_model: Type[models.BaseUserDB],
     authenticator: Authenticator,
     reset_password_token_secret: str,
     reset_password_token_lifetime_seconds: int = 3600,
 ) -> UserRouter:
     """Generate a router with the authentication routes."""
     router = UserRouter()
-    models = Models(user_model)
 
     reset_password_token_audience = "fastapi-users:reset"
 
     get_current_active_user = authenticator.get_current_active_user
     get_current_superuser = authenticator.get_current_superuser
 
-    async def _get_or_404(id: str) -> models.UserDB:  # type: ignore
+    async def _get_or_404(id: str) -> models.BaseUserDB:
         user = await user_db.get(id)
         if user is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         return user
 
-    async def _update_user(
-        user: models.UserDB, update_dict: typing.Dict[str, typing.Any]  # type: ignore
-    ):
+    async def _update_user(user: models.BaseUserDB, update_dict: Dict[str, Any]):
         for field in update_dict:
             if field == "password":
                 hashed_password = get_password_hash(update_dict[field])
@@ -101,9 +101,10 @@ def get_user_router(
         _add_login_route(router, user_db, auth_backend)
 
     @router.post(
-        "/register", response_model=models.User, status_code=status.HTTP_201_CREATED
+        "/register", response_model=user_model, status_code=status.HTTP_201_CREATED
     )
-    async def register(user: models.UserCreate):  # type: ignore
+    async def register(user: user_create_model):  # type: ignore
+        user = cast(models.BaseUserCreate, user)  # Prevent mypy complain
         existing_user = await user_db.get_by_email(user.email)
 
         if existing_user is not None:
@@ -113,7 +114,7 @@ def get_user_router(
             )
 
         hashed_password = get_password_hash(user.password)
-        db_user = models.UserDB(
+        db_user = user_db_model(
             **user.create_update_dict(), hashed_password=hashed_password
         )
         created_user = await user_db.create(db_user)
@@ -168,47 +169,49 @@ def get_user_router(
                 detail=ErrorCode.RESET_PASSWORD_BAD_TOKEN,
             )
 
-    @router.get("/me", response_model=models.User)
+    @router.get("/me", response_model=user_model)
     async def me(
-        user: models.UserDB = Depends(get_current_active_user),  # type: ignore
+        user: user_db_model = Depends(get_current_active_user),  # type: ignore
     ):
         return user
 
-    @router.patch("/me", response_model=models.User)
+    @router.patch("/me", response_model=user_model)
     async def update_me(
-        updated_user: models.UserUpdate,  # type: ignore
-        user: models.UserDB = Depends(get_current_active_user),  # type: ignore
+        updated_user: user_update_model,  # type: ignore
+        user: user_db_model = Depends(get_current_active_user),  # type: ignore
     ):
+        updated_user = cast(
+            models.BaseUserUpdate, updated_user,
+        )  # Prevent mypy complain
         updated_user_data = updated_user.create_update_dict()
         return await _update_user(user, updated_user_data)
 
-    @router.get("/", response_model=typing.List[models.User])  # type: ignore
-    async def list_users(
-        superuser: models.UserDB = Depends(get_current_superuser),  # type: ignore
-    ):
+    @router.get("/", response_model=List[user_model])  # type: ignore
+    async def list_users(superuser=Depends(get_current_superuser),):
         return await user_db.list()
 
-    @router.get("/{id}", response_model=models.User)
+    @router.get("/{id}", response_model=user_model)
     async def get_user(
-        id: str,
-        superuser: models.UserDB = Depends(get_current_superuser),  # type: ignore
+        id: str, superuser=Depends(get_current_superuser),
     ):
         return await _get_or_404(id)
 
-    @router.patch("/{id}", response_model=models.User)
+    @router.patch("/{id}", response_model=user_model)
     async def update_user(
         id: str,
-        updated_user: models.UserUpdate,  # type: ignore
-        superuser: models.UserDB = Depends(get_current_superuser),  # type: ignore
+        updated_user: user_update_model,  # type: ignore
+        superuser=Depends(get_current_superuser),
     ):
+        updated_user = cast(
+            models.BaseUserUpdate, updated_user,
+        )  # Prevent mypy complain
         user = await _get_or_404(id)
         updated_user_data = updated_user.create_update_dict_superuser()
         return await _update_user(user, updated_user_data)
 
     @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
     async def delete_user(
-        id: str,
-        superuser: models.UserDB = Depends(get_current_superuser),  # type: ignore
+        id: str, superuser=Depends(get_current_superuser),
     ):
         user = await _get_or_404(id)
         await user_db.delete(user)

--- a/tests/test_authentication_cookie.py
+++ b/tests/test_authentication_cookie.py
@@ -84,9 +84,7 @@ async def test_get_login_response(cookie_authentication, user):
     # so that FastAPI can terminate it properly
     assert login_response is None
 
-    cookies = [
-        header for header in response.raw_headers if header[0] == b"set-cookie"
-    ]
+    cookies = [header for header in response.raw_headers if header[0] == b"set-cookie"]
     assert len(cookies) == 1
 
     cookie = cookies[0][1].decode("latin-1")

--- a/tests/test_db_base.py
+++ b/tests/test_db_base.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.security import OAuth2PasswordRequestForm
 
 from fastapi_users.db import BaseUserDatabase
+from tests.conftest import UserDB
 
 
 @pytest.fixture
@@ -15,7 +16,7 @@ def create_oauth2_password_request_form():
 @pytest.mark.asyncio
 @pytest.mark.db
 async def test_not_implemented_methods(user):
-    base_user_db = BaseUserDatabase()
+    base_user_db = BaseUserDatabase(UserDB)
 
     with pytest.raises(NotImplementedError):
         await base_user_db.list()

--- a/tests/test_db_tortoise.py
+++ b/tests/test_db_tortoise.py
@@ -4,12 +4,12 @@ import pytest
 from tortoise.exceptions import IntegrityError
 from tortoise import Tortoise, fields
 
-from fastapi_users.db.tortoise import TortoiseUserDatabase, BaseUserModel
+from fastapi_users.db.tortoise import TortoiseUserDatabase, TortoiseBaseUserModel
 from fastapi_users.password import get_password_hash
 from tests.conftest import UserDB
 
 
-class User(BaseUserModel):
+class User(TortoiseBaseUserModel):
     first_name = fields.CharField(null=True, max_length=255)
 
 

--- a/tests/test_db_tortoise.py
+++ b/tests/test_db_tortoise.py
@@ -1,16 +1,16 @@
 from typing import AsyncGenerator
 
 import pytest
-from tortoise import Model
 from tortoise.exceptions import IntegrityError
-from tortoise import Tortoise
+from tortoise import Tortoise, fields
+
 from fastapi_users.db.tortoise import TortoiseUserDatabase, BaseUserModel
-from fastapi_users.models import BaseUserDB
 from fastapi_users.password import get_password_hash
+from tests.conftest import UserDB
 
 
-class User(BaseUserModel, Model):
-    pass
+class User(BaseUserModel):
+    first_name = fields.CharField(null=True, max_length=255)
 
 
 @pytest.fixture
@@ -22,7 +22,7 @@ async def tortoise_user_db() -> AsyncGenerator[TortoiseUserDatabase, None]:
     )
     await Tortoise.generate_schemas()
 
-    yield TortoiseUserDatabase(User)
+    yield TortoiseUserDatabase(UserDB, User)
 
     await User.all().delete()
     await Tortoise.close_connections()
@@ -30,8 +30,8 @@ async def tortoise_user_db() -> AsyncGenerator[TortoiseUserDatabase, None]:
 
 @pytest.mark.asyncio
 @pytest.mark.db
-async def test_queries(tortoise_user_db: TortoiseUserDatabase):
-    user = BaseUserDB(
+async def test_queries(tortoise_user_db: TortoiseUserDatabase[UserDB]):
+    user = UserDB(
         id="111",
         email="lancelot@camelot.bt",
         hashed_password=get_password_hash("guinevere"),
@@ -50,11 +50,13 @@ async def test_queries(tortoise_user_db: TortoiseUserDatabase):
 
     # Get by id
     id_user = await tortoise_user_db.get(user.id)
+    assert id_user is not None
     assert id_user.id == user_db.id
     assert id_user.is_superuser is True
 
     # Get by email
-    email_user = await tortoise_user_db.get_by_email(user.email)
+    email_user = await tortoise_user_db.get_by_email(str(user.email))
+    assert email_user is not None
     assert email_user.id == user_db.id
 
     # List
@@ -69,7 +71,7 @@ async def test_queries(tortoise_user_db: TortoiseUserDatabase):
 
     # Exception when inserting non-nullable fields
     with pytest.raises(ValueError):
-        wrong_user = BaseUserDB(id="222", hashed_password="aaa")
+        wrong_user = UserDB(id="222", hashed_password="aaa")
         await tortoise_user_db.create(wrong_user)
 
     # Unknown user
@@ -80,3 +82,21 @@ async def test_queries(tortoise_user_db: TortoiseUserDatabase):
     await tortoise_user_db.delete(user)
     deleted_user = await tortoise_user_db.get(user.id)
     assert deleted_user is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.db
+async def test_queries_custom_fields(tortoise_user_db: TortoiseUserDatabase[UserDB]):
+    """It should output custom fields in query result."""
+    user = UserDB(
+        id="111",
+        email="lancelot@camelot.bt",
+        hashed_password=get_password_hash("guinevere"),
+        first_name="Lancelot",
+    )
+    await tortoise_user_db.create(user)
+
+    id_user = await tortoise_user_db.get(user.id)
+    assert id_user is not None
+    assert id_user.id == user.id
+    assert id_user.first_name == user.first_name


### PR DESCRIPTION
This should fix #83 

It introduces breaking change because we'll now ask the end-developer to declare each Pydantic model variations (User, UserCreate, UserUpdate and UserDB) and to pass the UserDB model into the DB adapters.

It may sound a bit tedious but I think it's better because there is now less hidden magic and that enables the developer to fine tune the validation for registration and profile update.

It also includes some changes to the Tortoise integration. 