### PR TITLE
Use real UUID for User id. and OAuthAccount id.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ format: isort-src isort-docs
 test:
 	docker stop $(MONGODB_CONTAINER_NAME) || true
 	docker run -d --rm --name $(MONGODB_CONTAINER_NAME) -p 27017:27017 mvertes/alpine-mongo
-	$(PIPENV_RUN) pytest --cov=fastapi_users/
+	$(PIPENV_RUN) pytest --cov=fastapi_users/ --cov-report=term-missing
 	docker stop $(MONGODB_CONTAINER_NAME)
 
 docs-serve:

--- a/docs/configuration/databases/mongodb.md
+++ b/docs/configuration/databases/mongodb.md
@@ -12,11 +12,14 @@ Let's create a MongoDB connection and instantiate a collection.
 
 You can choose any name for the database and the collection.
 
+!!! warning
+    You may have noticed the `uuidRepresentation` parameter. It controls how the UUID values will be encoded in the database. By default, it's set to `pythonLegacy` but new applications should consider setting this to `standard` for cross language compatibility. [Read more about this](https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient).
+
 ## Create the database adapter
 
 The database adapter of **FastAPI Users** makes the link between your database configuration and the users logic. Create it like this.
 
-```py hl_lines="32"
+```py hl_lines="34"
 {!./src/db_mongodb.py!}
 ```
 
@@ -26,7 +29,7 @@ Notice that we pass a reference to your [`UserDB` model](../model.md).
     The database adapter will automatically create a [unique index](https://docs.mongodb.com/manual/core/index-unique/) on `id` and `email`.
 
 !!! warning
-    **FastAPI Users** will use its defined [`id` UUID-string](../model.md) as unique identifier for the user, rather than the builtin MongoDB `_id`.
+    **FastAPI Users** will use its defined [`id` UUID](../model.md) as unique identifier for the user, rather than the builtin MongoDB `_id`.
 
 ## Next steps
 

--- a/docs/configuration/model.md
+++ b/docs/configuration/model.md
@@ -2,7 +2,7 @@
 
 **FastAPI Users** defines a minimal User model for authentication purposes. It is structured like this:
 
-* `id` (`str`) – Unique identifier of the user. Default to a **UUID4**.
+* `id` (`UUID4`) – Unique identifier of the user. Default to a **UUID4**.
 * `email` (`str`) – Email of the user. Validated by [`email-validator`](https://github.com/JoshData/python-email-validator).
 * `is_active` (`bool`) – Whether or not the user is active. If not, login and forgot password requests will be denied. Default to `True`.
 * `is_superuser` (`bool`) – Whether or not the user is a superuser. Useful to implement administration logic. Default to `False`.

--- a/docs/configuration/oauth.md
+++ b/docs/configuration/oauth.md
@@ -56,7 +56,7 @@ class UserDB(User, models.BaseUserDB):
 
 Notice that we inherit from the `BaseOAuthAccountMixin`, which adds a `List` of `BaseOAuthAccount` objects. This object is structured like this:
 
-* `id` (`str`) – Unique identifier of the user. Default to a **UUID4**.
+* `id` (`UUID4`) – Unique identifier of the OAuth account information. Default to a **UUID4**.
 * `oauth_name` (`str`) – Name of the OAuth service. It corresponds to the `name` property of the OAuth client.
 * `access_token` (`str`) – Access token.
 * `expires_at` (`int`) - Timestamp at which the access token is expired.
@@ -100,7 +100,7 @@ class OAuthAccount(TortoiseBaseOAuthAccountModel):
 ```
 
 !!! warning
-    Note that you shouls define the foreign key yourself, so that you can point it the user model in your namespace.
+    Note that you should define the foreign key yourself, so that you can point it the user model in your namespace.
 
 Then, you should declare it on the database adapter:
 

--- a/docs/migration/08_to_10.md
+++ b/docs/migration/08_to_10.md
@@ -1,0 +1,82 @@
+# 0.8.x ➡️ 1.0.x
+
+1.0 version introduces major breaking changes that need you to update some of your code and migrate your data.
+
+## Id. are UUID
+
+Users and OAuth accounts id. are now represented as real UUID objects instead of plain strings.  This change was introduced to leverage efficient storage and indexing for DBMS that supports UUID (especially PostgreSQL and Mongo).
+
+### In Python code
+
+If you were doing comparison betwen a user id. and a string (in unit tests for example), you should now cast the id. to string:
+
+```py
+# Before
+assert "d35d213e-f3d8-4f08-954a-7e0d1bea286f" == user.id
+
+# Now
+assert "d35d213e-f3d8-4f08-954a-7e0d1bea286f" == str(user.id)
+```
+
+If you were refering to user id. in your Pydantic models, the field should now be of `UUID4` type instead of `str`:
+
+```py
+from pydantic import BaseModel, UUID4
+
+# Before
+class Model(BaseModel):
+    user_id: str
+
+# After
+class Model(BaseModel):
+    user_id: UUID4
+```
+
+### In database
+
+Id. were before stored as strings in the database. You should make a migration to convert string data to UUID data.
+
+!!! danger
+    Scripts below are provided as guidelines. Please **review them carefully**, **adapt them** and check that they are working on a test database before applying them to production. **BE CAREFUL. THEY CAN DESTROY YOUR DATA.**.
+
+#### PostgreSQL
+
+PostgreSQL supports UUID type. If not already, you should enable the `uuid-ossp` extension:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+```
+
+To convert the existing id. string column, we can:
+
+1. Create a new column with UUID type.
+2. Fill it with the id. converted to UUID.
+3. Drop the original id. column.
+4. Make the new column a primary key and rename it.
+
+```sql
+ALTER TABLE "user" ADD uuid_id UUID;
+UPDATE "user" SET uuid_id = uuid(id);
+ALTER TABLE "user" DROP id;
+ALTER TABLE "user" ADD PRIMARY KEY (uuid_id);
+ALTER TABLE "user" RENAME COLUMN uuid_id TO id;
+```
+
+#### MySQL
+
+MySQL doesn't support UUID type. We'll just convert the column to `CHAR(36)` type:
+
+```sql
+ALTER TABLE "user" MODIFY id CHAR(36);
+```
+
+#### MongoDB
+
+For MongoDB, we can use a `forEach` iterator to convert the id. for each document:
+
+```js
+db.getCollection('users').find().forEach(function(user) {
+  var uuid = UUID(user.id);
+  db.getCollection('users').update({_id: user._id}, [{$set: {id: uuid}}]);
+});
+```

--- a/docs/src/db_mongodb.py
+++ b/docs/src/db_mongodb.py
@@ -21,7 +21,9 @@ class UserDB(User, models.BaseUserDB):
 
 
 DATABASE_URL = "mongodb://localhost:27017"
-client = motor.motor_asyncio.AsyncIOMotorClient(DATABASE_URL)
+client = motor.motor_asyncio.AsyncIOMotorClient(
+    DATABASE_URL, uuidRepresentation="standard"
+)
 db = client["database_name"]
 collection = db["users"]
 

--- a/docs/src/full_mongodb.py
+++ b/docs/src/full_mongodb.py
@@ -25,7 +25,9 @@ class UserDB(User, models.BaseUserDB):
     pass
 
 
-client = motor.motor_asyncio.AsyncIOMotorClient(DATABASE_URL)
+client = motor.motor_asyncio.AsyncIOMotorClient(
+    DATABASE_URL, uuidRepresentation="standard"
+)
 db = client["database_name"]
 collection = db["users"]
 user_db = MongoDBUserDatabase(UserDB, collection)

--- a/docs/src/oauth_full_mongodb.py
+++ b/docs/src/oauth_full_mongodb.py
@@ -29,7 +29,9 @@ class UserDB(User, models.BaseUserDB):
     pass
 
 
-client = motor.motor_asyncio.AsyncIOMotorClient(DATABASE_URL)
+client = motor.motor_asyncio.AsyncIOMotorClient(
+    DATABASE_URL, uuidRepresentation="standard"
+)
 db = client["database_name"]
 collection = db["users"]
 user_db = MongoDBUserDatabase(UserDB, collection)

--- a/fastapi_users/db/base.py
+++ b/fastapi_users/db/base.py
@@ -1,6 +1,7 @@
 from typing import Generic, Optional, Type
 
 from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import UUID4
 
 from fastapi_users import password
 from fastapi_users.models import UD
@@ -18,7 +19,7 @@ class BaseUserDatabase(Generic[UD]):
     def __init__(self, user_db_model: Type[UD]):
         self.user_db_model = user_db_model
 
-    async def get(self, id: str) -> Optional[UD]:
+    async def get(self, id: UUID4) -> Optional[UD]:
         """Get a single user by id."""
         raise NotImplementedError()
 

--- a/fastapi_users/db/mongodb.py
+++ b/fastapi_users/db/mongodb.py
@@ -1,6 +1,7 @@
 from typing import Optional, Type
 
 from motor.motor_asyncio import AsyncIOMotorCollection
+from pydantic import UUID4
 
 from fastapi_users.db.base import BaseUserDatabase
 from fastapi_users.models import UD
@@ -22,7 +23,7 @@ class MongoDBUserDatabase(BaseUserDatabase[UD]):
         self.collection.create_index("id", unique=True)
         self.collection.create_index("email", unique=True)
 
-    async def get(self, id: str) -> Optional[UD]:
+    async def get(self, id: UUID4) -> Optional[UD]:
         user = await self.collection.find_one({"id": id})
         return self.user_db_model(**user) if user else None
 

--- a/fastapi_users/db/sqlalchemy.py
+++ b/fastapi_users/db/sqlalchemy.py
@@ -1,11 +1,51 @@
+import uuid
 from typing import Mapping, Optional, Type
 
 from databases import Database
+from pydantic import UUID4
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Table, select
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.types import CHAR, TypeDecorator
 
 from fastapi_users.db.base import BaseUserDatabase
 from fastapi_users.models import UD
+
+
+class GUID(TypeDecorator):  # pragma: no cover
+    """Platform-independent GUID type.
+
+    Uses PostgreSQL's UUID type, otherwise uses
+    CHAR(32), storing as stringified hex values.
+    """
+
+    impl = CHAR
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(UUID())
+        else:
+            return dialect.type_descriptor(CHAR(32))
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        elif dialect.name == "postgresql":
+            return str(value)
+        else:
+            if not isinstance(value, uuid.UUID):
+                return "%.32x" % uuid.UUID(value).int
+            else:
+                # hexstring
+                return "%.32x" % value.int
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+        else:
+            if not isinstance(value, uuid.UUID):
+                value = uuid.UUID(value)
+            return value
 
 
 class SQLAlchemyBaseUserTable:
@@ -13,7 +53,7 @@ class SQLAlchemyBaseUserTable:
 
     __tablename__ = "user"
 
-    id = Column(String, primary_key=True)
+    id = Column(GUID, primary_key=True)
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
@@ -25,7 +65,7 @@ class SQLAlchemyBaseOAuthAccountTable:
 
     __tablename__ = "oauth_account"
 
-    id = Column(String, primary_key=True)
+    id = Column(GUID, primary_key=True)
     oauth_name = Column(String, index=True, nullable=False)
     access_token = Column(String, nullable=False)
     expires_at = Column(Integer, nullable=False)
@@ -35,7 +75,7 @@ class SQLAlchemyBaseOAuthAccountTable:
 
     @declared_attr
     def user_id(cls):
-        return Column(String, ForeignKey("user.id", ondelete="cascade"), nullable=False)
+        return Column(GUID, ForeignKey("user.id", ondelete="cascade"), nullable=False)
 
 
 class NotSetOAuthAccountTableError(Exception):
@@ -75,7 +115,7 @@ class SQLAlchemyUserDatabase(BaseUserDatabase[UD]):
         self.users = users
         self.oauth_accounts = oauth_accounts
 
-    async def get(self, id: str) -> Optional[UD]:
+    async def get(self, id: UUID4) -> Optional[UD]:
         query = self.users.select().where(self.users.c.id == id)
         user = await self.database.fetch_one(query)
         return await self._make_user(user) if user else None

--- a/fastapi_users/db/sqlalchemy.py
+++ b/fastapi_users/db/sqlalchemy.py
@@ -16,7 +16,7 @@ class GUID(TypeDecorator):  # pragma: no cover
     """Platform-independent GUID type.
 
     Uses PostgreSQL's UUID type, otherwise uses
-    CHAR(32), storing as stringified hex values.
+    CHAR(36), storing as regular strings.
     """
 
     impl = CHAR
@@ -25,7 +25,7 @@ class GUID(TypeDecorator):  # pragma: no cover
         if dialect.name == "postgresql":
             return dialect.type_descriptor(UUID())
         else:
-            return dialect.type_descriptor(CHAR(32))
+            return dialect.type_descriptor(CHAR(36))
 
     def process_bind_param(self, value, dialect):
         if value is None:
@@ -34,10 +34,9 @@ class GUID(TypeDecorator):  # pragma: no cover
             return str(value)
         else:
             if not isinstance(value, uuid.UUID):
-                return "%.32x" % uuid.UUID(value).int
+                return str(uuid.UUID(value))
             else:
-                # hexstring
-                return "%.32x" % value.int
+                return str(value)
 
     def process_result_value(self, value, dialect):
         if value is None:

--- a/fastapi_users/db/tortoise.py
+++ b/fastapi_users/db/tortoise.py
@@ -1,5 +1,6 @@
 from typing import Optional, Type
 
+from pydantic import UUID4
 from tortoise import fields, models
 from tortoise.exceptions import DoesNotExist
 
@@ -8,7 +9,7 @@ from fastapi_users.models import UD
 
 
 class TortoiseBaseUserModel(models.Model):
-    id = fields.CharField(pk=True, generated=False, max_length=255)
+    id = fields.UUIDField(pk=True, generated=False)
     email = fields.CharField(index=True, unique=True, null=False, max_length=255)
     hashed_password = fields.CharField(null=False, max_length=255)
     is_active = fields.BooleanField(default=True, null=False)
@@ -27,7 +28,7 @@ class TortoiseBaseUserModel(models.Model):
 
 
 class TortoiseBaseOAuthAccountModel(models.Model):
-    id = fields.CharField(pk=True, generated=False, max_length=255)
+    id = fields.UUIDField(pk=True, generated=False, max_length=255)
     oauth_name = fields.CharField(null=False, max_length=255)
     access_token = fields.CharField(null=False, max_length=255)
     expires_at = fields.IntField(null=False)
@@ -61,7 +62,7 @@ class TortoiseUserDatabase(BaseUserDatabase[UD]):
         self.model = model
         self.oauth_account_model = oauth_account_model
 
-    async def get(self, id: str) -> Optional[UD]:
+    async def get(self, id: UUID4) -> Optional[UD]:
         try:
             query = self.model.get(id=id)
 

--- a/fastapi_users/models.py
+++ b/fastapi_users/models.py
@@ -1,21 +1,20 @@
 import uuid
 from typing import List, Optional, TypeVar
 
-import pydantic
-from pydantic import BaseModel, EmailStr
+from pydantic import UUID4, BaseModel, EmailStr, validator
 
 
 class BaseUser(BaseModel):
     """Base User model."""
 
-    id: Optional[str] = None
+    id: Optional[UUID4] = None
     email: Optional[EmailStr] = None
     is_active: Optional[bool] = True
     is_superuser: Optional[bool] = False
 
-    @pydantic.validator("id", pre=True, always=True)
+    @validator("id", pre=True, always=True)
     def default_id(cls, v):
-        return v or str(uuid.uuid4())
+        return v or uuid.uuid4()
 
     def create_update_dict(self):
         return self.dict(
@@ -37,7 +36,7 @@ class BaseUserUpdate(BaseUser):
 
 
 class BaseUserDB(BaseUser):
-    id: str
+    id: UUID4
     hashed_password: str
 
     class Config:
@@ -50,7 +49,7 @@ UD = TypeVar("UD", bound=BaseUserDB)
 class BaseOAuthAccount(BaseModel):
     """Base OAuth account model."""
 
-    id: Optional[str] = None
+    id: Optional[UUID4] = None
     oauth_name: str
     access_token: str
     expires_at: int
@@ -58,9 +57,9 @@ class BaseOAuthAccount(BaseModel):
     account_id: str
     account_email: str
 
-    @pydantic.validator("id", pre=True, always=True)
+    @validator("id", pre=True, always=True)
     def default_id(cls, v):
-        return v or str(uuid.uuid4())
+        return v or uuid.uuid4()
 
     class Config:
         orm_mode = True

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,3 +45,5 @@ nav:
     - usage/flow.md
     - usage/routes.md
     - usage/dependency-callables.md
+  - Migration:
+    - migration/08_to_10.md

--- a/tests/test_authentication_cookie.py
+++ b/tests/test_authentication_cookie.py
@@ -31,7 +31,7 @@ def token():
     def _token(user=None, lifetime=LIFETIME):
         data = {"aud": "fastapi-users:auth"}
         if user is not None:
-            data["user_id"] = user.id
+            data["user_id"] = str(user.id)
         return generate_jwt(data, lifetime, SECRET, JWT_ALGORITHM)
 
     return _token
@@ -131,7 +131,7 @@ async def test_get_login_response(
     decoded = jwt.decode(
         cookie_value, SECRET, audience="fastapi-users:auth", algorithms=[JWT_ALGORITHM]
     )
-    assert decoded["user_id"] == user.id
+    assert decoded["user_id"] == str(user.id)
 
 
 @pytest.mark.authentication
@@ -149,4 +149,4 @@ async def test_get_logout_response(user):
 
     cookie = cookies[0][1].decode("latin-1")
 
-    assert f"Max-Age=0" in cookie
+    assert "Max-Age=0" in cookie

--- a/tests/test_db_mongodb.py
+++ b/tests/test_db_mongodb.py
@@ -15,7 +15,9 @@ def get_mongodb_user_db():
         user_model,
     ) -> AsyncGenerator[MongoDBUserDatabase, None]:
         client = motor.motor_asyncio.AsyncIOMotorClient(
-            "mongodb://localhost:27017", serverSelectionTimeoutMS=100
+            "mongodb://localhost:27017",
+            serverSelectionTimeoutMS=100,
+            uuidRepresentation="standard",
         )
 
         try:
@@ -50,9 +52,7 @@ async def mongodb_user_db_oauth(get_mongodb_user_db):
 @pytest.mark.db
 async def test_queries(mongodb_user_db: MongoDBUserDatabase[UserDB]):
     user = UserDB(
-        id="111",
-        email="lancelot@camelot.bt",
-        hashed_password=get_password_hash("guinevere"),
+        email="lancelot@camelot.bt", hashed_password=get_password_hash("guinevere"),
     )
 
     # Create
@@ -96,7 +96,6 @@ async def test_queries(mongodb_user_db: MongoDBUserDatabase[UserDB]):
 async def test_queries_custom_fields(mongodb_user_db: MongoDBUserDatabase[UserDB]):
     """It should output custom fields in query result."""
     user = UserDB(
-        id="111",
         email="lancelot@camelot.bt",
         hashed_password=get_password_hash("guinevere"),
         first_name="Lancelot",
@@ -117,7 +116,6 @@ async def test_queries_oauth(
     oauth_account2,
 ):
     user = UserDBOAuth(
-        id="111",
         email="lancelot@camelot.bt",
         hashed_password=get_password_hash("guinevere"),
         oauth_accounts=[oauth_account1, oauth_account2],

--- a/tests/test_db_sqlalchemy.py
+++ b/tests/test_db_sqlalchemy.py
@@ -70,9 +70,7 @@ async def sqlalchemy_user_db_oauth() -> AsyncGenerator[SQLAlchemyUserDatabase, N
 @pytest.mark.db
 async def test_queries(sqlalchemy_user_db: SQLAlchemyUserDatabase[UserDB]):
     user = UserDB(
-        id="111",
-        email="lancelot@camelot.bt",
-        hashed_password=get_password_hash("guinevere"),
+        email="lancelot@camelot.bt", hashed_password=get_password_hash("guinevere"),
     )
 
     # Create
@@ -103,7 +101,7 @@ async def test_queries(sqlalchemy_user_db: SQLAlchemyUserDatabase[UserDB]):
 
     # Exception when inserting non-nullable fields
     with pytest.raises(sqlite3.IntegrityError):
-        wrong_user = UserDB(id="222", hashed_password="aaa")
+        wrong_user = UserDB(hashed_password="aaa")
         await sqlalchemy_user_db.create(wrong_user)
 
     # Unknown user
@@ -117,9 +115,7 @@ async def test_queries(sqlalchemy_user_db: SQLAlchemyUserDatabase[UserDB]):
 
     # Exception when creating/updating a OAuth user
     user_oauth = UserDBOAuth(
-        id="222",
-        email="lancelot@camelot.bt",
-        hashed_password=get_password_hash("guinevere"),
+        email="lancelot@camelot.bt", hashed_password=get_password_hash("guinevere"),
     )
     with pytest.raises(NotSetOAuthAccountTableError):
         await sqlalchemy_user_db.create(user_oauth)
@@ -138,7 +134,6 @@ async def test_queries_custom_fields(
 ):
     """It should output custom fields in query result."""
     user = UserDB(
-        id="111",
         email="lancelot@camelot.bt",
         hashed_password=get_password_hash("guinevere"),
         first_name="Lancelot",
@@ -159,7 +154,6 @@ async def test_queries_oauth(
     oauth_account2,
 ):
     user = UserDBOAuth(
-        id="111",
         email="lancelot@camelot.bt",
         hashed_password=get_password_hash("guinevere"),
         oauth_accounts=[oauth_account1, oauth_account2],

--- a/tests/test_db_tortoise.py
+++ b/tests/test_db_tortoise.py
@@ -55,9 +55,7 @@ async def tortoise_user_db_oauth() -> AsyncGenerator[TortoiseUserDatabase, None]
 @pytest.mark.db
 async def test_queries(tortoise_user_db: TortoiseUserDatabase[UserDB]):
     user = UserDB(
-        id="111",
-        email="lancelot@camelot.bt",
-        hashed_password=get_password_hash("guinevere"),
+        email="lancelot@camelot.bt", hashed_password=get_password_hash("guinevere"),
     )
 
     # Create
@@ -88,7 +86,7 @@ async def test_queries(tortoise_user_db: TortoiseUserDatabase[UserDB]):
 
     # Exception when inserting non-nullable fields
     with pytest.raises(ValueError):
-        wrong_user = UserDB(id="222", hashed_password="aaa")
+        wrong_user = UserDB(hashed_password="aaa")
         await tortoise_user_db.create(wrong_user)
 
     # Unknown user
@@ -106,7 +104,6 @@ async def test_queries(tortoise_user_db: TortoiseUserDatabase[UserDB]):
 async def test_queries_custom_fields(tortoise_user_db: TortoiseUserDatabase[UserDB]):
     """It should output custom fields in query result."""
     user = UserDB(
-        id="111",
         email="lancelot@camelot.bt",
         hashed_password=get_password_hash("guinevere"),
         first_name="Lancelot",
@@ -127,7 +124,6 @@ async def test_queries_oauth(
     oauth_account2,
 ):
     user = UserDBOAuth(
-        id="111",
         email="lancelot@camelot.bt",
         hashed_password=get_password_hash("guinevere"),
         oauth_accounts=[oauth_account1, oauth_account2],

--- a/tests/test_router_oauth.py
+++ b/tests/test_router_oauth.py
@@ -204,7 +204,7 @@ class TestCallback:
         user_update_mock.assert_awaited_once()
         data = cast(Dict[str, Any], response.json())
 
-        assert data["token"] == user_oauth.id
+        assert data["token"] == str(user_oauth.id)
 
         assert event_handler.called is False
 
@@ -242,7 +242,7 @@ class TestCallback:
         user_update_mock.assert_awaited_once()
         data = cast(Dict[str, Any], response.json())
 
-        assert data["token"] == superuser_oauth.id
+        assert data["token"] == str(superuser_oauth.id)
 
         assert event_handler.called is False
 
@@ -283,7 +283,7 @@ class TestCallback:
 
         assert event_handler.called is True
         actual_user = event_handler.call_args[0][0]
-        assert actual_user.id == data["token"]
+        assert str(actual_user.id) == data["token"]
         request = event_handler.call_args[0][1]
         assert isinstance(request, Request)
 
@@ -348,4 +348,4 @@ class TestCallback:
         )
         data = cast(Dict[str, Any], response.json())
 
-        assert data["token"] == user_oauth.id
+        assert data["token"] == str(user_oauth.id)


### PR DESCRIPTION
This will be a major breaking change. The point is to leverage efficient storage and indexing for DBMS that supports UUID (PostgreSQL and Mongo).

- [x] Migrate the code
- [x] Update unit tests
- [x] Update the documentation
- [x] Write a migration page with SQL/Mongo queries to update existing records