### PR TITLE
fix documentation tokenUrl

### DIFF
--- a/docs/src/full_mongodb.py
+++ b/docs/src/full_mongodb.py
@@ -40,7 +40,7 @@ def on_after_forgot_password(user: UserDB, token: str, request: Request):
     print(f"User {user.id} has forgot their password. Reset token: {token}")
 
 
-jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
+jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600, tokenUrl='/auth/jwt/login')
 
 app = FastAPI()
 fastapi_users = FastAPIUsers(

--- a/docs/src/full_sqlalchemy.py
+++ b/docs/src/full_sqlalchemy.py
@@ -51,7 +51,7 @@ def on_after_forgot_password(user: UserDB, token: str, request: Request):
     print(f"User {user.id} has forgot their password. Reset token: {token}")
 
 
-jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
+jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600, tokenUrl='/auth/jwt/login')
 
 app = FastAPI()
 fastapi_users = FastAPIUsers(

--- a/docs/src/full_tortoise.py
+++ b/docs/src/full_tortoise.py
@@ -41,7 +41,7 @@ def on_after_forgot_password(user: UserDB, token: str, request: Request):
     print(f"User {user.id} has forgot their password. Reset token: {token}")
 
 
-jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
+jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600, tokenUrl='/auth/jwt/login')
 
 fastapi_users = FastAPIUsers(
     user_db, [jwt_authentication], User, UserCreate, UserUpdate, UserDB,

--- a/docs/src/oauth_full_mongodb.py
+++ b/docs/src/oauth_full_mongodb.py
@@ -44,7 +44,7 @@ def on_after_forgot_password(user: UserDB, token: str, request: Request):
     print(f"User {user.id} has forgot their password. Reset token: {token}")
 
 
-jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
+jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600, tokenUrl='/auth/jwt/login')
 
 app = FastAPI()
 fastapi_users = FastAPIUsers(

--- a/docs/src/oauth_full_sqlalchemy.py
+++ b/docs/src/oauth_full_sqlalchemy.py
@@ -64,7 +64,7 @@ def on_after_forgot_password(user: UserDB, token: str, request: Request):
     print(f"User {user.id} has forgot their password. Reset token: {token}")
 
 
-jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
+jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600, tokenUrl='/auth/jwt/login')
 
 app = FastAPI()
 fastapi_users = FastAPIUsers(

--- a/docs/src/oauth_full_tortoise.py
+++ b/docs/src/oauth_full_tortoise.py
@@ -54,7 +54,7 @@ def on_after_forgot_password(user: UserDB, token: str, request: Request):
     print(f"User {user.id} has forgot their password. Reset token: {token}")
 
 
-jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
+jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600, tokenUrl='/auth/jwt/login')
 
 fastapi_users = FastAPIUsers(
     user_db, [jwt_authentication], User, UserCreate, UserUpdate, UserDB,

--- a/fastapi_users/authentication/jwt.py
+++ b/fastapi_users/authentication/jwt.py
@@ -30,7 +30,7 @@ class JWTAuthentication(BaseAuthentication[str]):
         self,
         secret: str,
         lifetime_seconds: int,
-        tokenUrl: str = "/users/login",
+        tokenUrl: str = "/login",
         name: str = "jwt",
     ):
         super().__init__(name, logout=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ def mock_user_db_oauth(
 class MockAuthentication(BaseAuthentication[str]):
     def __init__(self, name: str = "mock"):
         super().__init__(name, logout=True)
-        self.scheme = OAuth2PasswordBearer("/users/login", auto_error=False)
+        self.scheme = OAuth2PasswordBearer("/login", auto_error=False)
 
     async def __call__(self, credentials: Optional[str], user_db: BaseUserDatabase):
         if credentials is not None:


### PR DESCRIPTION
**Problem**

Swagger documentation of [full example files](https://frankie567.github.io/fastapi-users/configuration/full_example/) cannot authorize token to be used, because tokenUrl is not set.

**Solution**

[Change the default tokenUrl](https://github.com/frankie567/fastapi-users/blob/master/fastapi_users/authentication/jwt.py#L33) of `JWTAuthentication` methods of all `example files`.

Issue (https://github.com/frankie567/fastapi-users/issues/211)