### PR TITLE
fix "Authorization: Bearer Undefined" on Swagger

### DIFF
--- a/docs/configuration/authentication/jwt.md
+++ b/docs/configuration/authentication/jwt.md
@@ -36,7 +36,8 @@ This method will return a JWT token upon successful login:
 !!! success "`200 OK`"
     ```json
     {
-        "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiOTIyMWZmYzktNjQwZi00MzcyLTg2ZDMtY2U2NDJjYmE1NjAzIiwiYXVkIjoiZmFzdGFwaS11c2VyczphdXRoIiwiZXhwIjoxNTcxNTA0MTkzfQ.M10bjOe45I5Ncu_uXvOmVV8QxnL-nZfcH96U90JaocI"
+        "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiOTIyMWZmYzktNjQwZi00MzcyLTg2ZDMtY2U2NDJjYmE1NjAzIiwiYXVkIjoiZmFzdGFwaS11c2VyczphdXRoIiwiZXhwIjoxNTcxNTA0MTkzfQ.M10bjOe45I5Ncu_uXvOmVV8QxnL-nZfcH96U90JaocI",
+        "token_type": "bearer"
     }
     ```
 

--- a/docs/usage/flow.md
+++ b/docs/usage/flow.md
@@ -94,7 +94,7 @@ You'll get a JSON response looking like this:
 
 ```json
 {
-    "token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNGZkMzQ3N2ItZWNjZi00ZWUzLThmN2QtNjhhZDcyMjYxNDc2IiwiYXVkIjoiZmFzdGFwaS11c2VyczphdXRoIiwiZXhwIjoxNTg3ODE4NDI5fQ.anO3JR8-WYCozZ4_2-PQ2Ov9O38RaLP2RAzQIiZhteM",
+    "access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNGZkMzQ3N2ItZWNjZi00ZWUzLThmN2QtNjhhZDcyMjYxNDc2IiwiYXVkIjoiZmFzdGFwaS11c2VyczphdXRoIiwiZXhwIjoxNTg3ODE4NDI5fQ.anO3JR8-WYCozZ4_2-PQ2Ov9O38RaLP2RAzQIiZhteM",
     "token_type": "bearer"
 }
 ```

--- a/docs/usage/flow.md
+++ b/docs/usage/flow.md
@@ -94,7 +94,8 @@ You'll get a JSON response looking like this:
 
 ```json
 {
-    "token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNGZkMzQ3N2ItZWNjZi00ZWUzLThmN2QtNjhhZDcyMjYxNDc2IiwiYXVkIjoiZmFzdGFwaS11c2VyczphdXRoIiwiZXhwIjoxNTg3ODE4NDI5fQ.anO3JR8-WYCozZ4_2-PQ2Ov9O38RaLP2RAzQIiZhteM"
+    "token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNGZkMzQ3N2ItZWNjZi00ZWUzLThmN2QtNjhhZDcyMjYxNDc2IiwiYXVkIjoiZmFzdGFwaS11c2VyczphdXRoIiwiZXhwIjoxNTg3ODE4NDI5fQ.anO3JR8-WYCozZ4_2-PQ2Ov9O38RaLP2RAzQIiZhteM",
+    "token_type": "bearer"
 }
 ```
 

--- a/fastapi_users/authentication/jwt.py
+++ b/fastapi_users/authentication/jwt.py
@@ -65,7 +65,7 @@ class JWTAuthentication(BaseAuthentication[str]):
 
     async def get_login_response(self, user: BaseUserDB, response: Response) -> Any:
         token = await self._generate_token(user)
-        return {"token": token}
+        return {"access_token": token, "token_type": "bearer"}
 
     async def _generate_token(self, user: BaseUserDB) -> str:
         data = {"user_id": str(user.id), "aud": self.token_audience}

--- a/tests/test_authentication_jwt.py
+++ b/tests/test_authentication_jwt.py
@@ -68,7 +68,7 @@ class TestAuthenticate:
 async def test_get_login_response(jwt_authentication, user):
     login_response = await jwt_authentication.get_login_response(user, Response())
 
-    assert "token" in login_response
+    assert "access_token" in login_response
 
     token = login_response["token"]
     decoded = jwt.decode(

--- a/tests/test_authentication_jwt.py
+++ b/tests/test_authentication_jwt.py
@@ -69,6 +69,7 @@ async def test_get_login_response(jwt_authentication, user):
     login_response = await jwt_authentication.get_login_response(user, Response())
 
     assert "access_token" in login_response
+    assert login_response["token_type"] == "bearer"
 
     token = login_response["access_token"]
     decoded = jwt.decode(

--- a/tests/test_authentication_jwt.py
+++ b/tests/test_authentication_jwt.py
@@ -70,7 +70,7 @@ async def test_get_login_response(jwt_authentication, user):
 
     assert "access_token" in login_response
 
-    token = login_response["token"]
+    token = login_response["access_token"]
     decoded = jwt.decode(
         token, SECRET, audience="fastapi-users:auth", algorithms=[JWT_ALGORITHM]
     )


### PR DESCRIPTION
This PR solves the issue https://github.com/frankie567/fastapi-users/issues/212

**Problem**

After authentication on Swagger documentation, the button `Try it out` generates `Undefined` instead of filling the Token of authenticated user.

**Solution**

Change the return of `get_login_response` on [jwt.py](https://github.com/frankie567/fastapi-users/blob/master/fastapi_users/authentication/jwt.py#L68) to match the expected return described at [fastapi's guides](https://github.com/tiangolo/fastapi/blob/master/docs_src/security/tutorial004.py#L128)

**Testing**

![image](https://user-images.githubusercontent.com/11466701/83456860-16546980-a493-11ea-877d-00ebcf82dcce.png)
