### PR TITLE
Use `Protocol` from `typing` if available

### DIFF
--- a/fastapi_users/user.py
+++ b/fastapi_users/user.py
@@ -1,6 +1,9 @@
 from typing import Awaitable, Type
 
-from typing_extensions import Protocol
+try:
+    from typing import Protocol
+except:
+    from typing_extensions import Protocol
 
 from fastapi_users import models
 from fastapi_users.db import BaseUserDatabase


### PR DESCRIPTION
Some of the 'experimental' definitions in typing_extensions are added to the typing module in time.

This PR prefers the stdlib imports when available, falling back to typing_extensions as necessary