### PR TITLE
Support oauth without email

### DIFF
--- a/fastapi_users/models.py
+++ b/fastapi_users/models.py
@@ -25,7 +25,7 @@ class BaseUser(CreateUpdateDictModel):
     """Base User model."""
 
     id: Optional[UUID4] = None
-    email: Optional[EmailStr] = None
+    email: Optional[str] = None
     is_active: Optional[bool] = True
     is_superuser: Optional[bool] = False
     is_verified: Optional[bool] = False

--- a/fastapi_users/router/oauth.py
+++ b/fastapi_users/router/oauth.py
@@ -97,6 +97,8 @@ def get_oauth_router(
         account_id, account_email = await oauth_client.get_id_email(
             token["access_token"]
         )
+        if account_email is None:
+            account_email = "@@{}:{}".format(oauth_client.name, account_id)
 
         try:
             state_data = decode_state_token(state, state_secret)


### PR DESCRIPTION
This is a proposed fix to #511. Specifically, when an oauth provider doesn't provide an email address, this inserts a field like `@@github:531534` as the email address.

I considered the approach of making emails on accounts optional, but this cause an issue with the unique index on the email field for databases (duplicate `NULL` email values). This needs a per-database solution and in Mongo, while there is a custom solution that will work, it causes lookups by email to be slow as they are no longer use an index in queries.

I also considered keeping the `EmailStr` type and making a pseudo-valid generated email like `1234@oauth:github` but this seems wrong because if `EmailStr` gets updated to be more constraininng we would need something more realistic like `1234@__oauth_github__.com` but then someone could potentially register with an oauth provider using that email and gain unauthorized access to an account. By using an invalid email prefix (`@@`) that is immediately infeasible and in code we can quickly check for the existence of an email with `user['email'].startswith(''@@")`.

Feel free to offer alternative solutions.