### PR TITLE
clean email modifiers

### DIFF
--- a/fastapi_users/user.py
+++ b/fastapi_users/user.py
@@ -11,6 +11,8 @@ from fastapi_users import models
 from fastapi_users.db import BaseUserDatabase
 from fastapi_users.password import get_password_hash
 
+import re
+
 
 class UserAlreadyExists(Exception):
     pass
@@ -45,7 +47,8 @@ def get_create_user(
         is_active: bool = None,
         is_verified: bool = None,
     ) -> models.BaseUserDB:
-        existing_user = await user_db.get_by_email(user.email)
+        no_plus_email = re.sub(r"(\+.*)@", "@", user.email)
+        existing_user = await user_db.get_by_email(no_plus_email)
 
         if existing_user is not None:
             raise UserAlreadyExists()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -28,6 +28,14 @@ class TestCreateUser:
         with pytest.raises(UserAlreadyExists):
             await create_user(user)
 
+    @pytest.mark.parametrize(
+        "email", ["king.arthur@camelot.bt", "King.Arthur+fake@camelot.bt"]
+    )
+    async def test_plus_in_email_user(self, email, create_user):
+        user = UserCreate(email=email, password="guinevere")
+        with pytest.raises(UserAlreadyExists):
+            await create_user(user)
+
     @pytest.mark.parametrize("email", ["lancelot@camelot.bt", "Lancelot@camelot.bt"])
     async def test_regular_user(self, email, create_user):
         user = UserCreate(email=email, password="guinevere")


### PR DESCRIPTION
prevents email modifiers to be used when registering avoiding duplicate emails (see #595) 