### PR TITLE
Added python_type into GUID

### DIFF
--- a/fastapi_users/db/sqlalchemy.py
+++ b/fastapi_users/db/sqlalchemy.py
@@ -18,8 +18,10 @@ class GUID(TypeDecorator):  # pragma: no cover
     Uses PostgreSQL's UUID type, otherwise uses
     CHAR(36), storing as regular strings.
     """
+    class UUIDChar(CHAR):
+        python_type = UUID4
 
-    impl = CHAR
+    impl = UUIDChar
 
     def load_dialect_impl(self, dialect):
         if dialect.name == "postgresql":


### PR DESCRIPTION
Added the python_type to the GUID class, by overriding CHAR. This is useful for libraries such pydantic-sqlalchemy where this attribute is used. (https://github.com/tiangolo/pydantic-sqlalchemy/blob/master/pydantic_sqlalchemy/main.py#L27)

This is to solve issue #646 