### PR TITLE
Return empty response with 204

### DIFF
--- a/fastapi_users/router/users.py
+++ b/fastapi_users/router/users.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Dict, Optional, Type, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status, Response
 from pydantic import UUID4
 
 from fastapi_users import models
@@ -138,6 +138,7 @@ def get_users_router(
     @router.delete(
         "/{id:uuid}",
         status_code=status.HTTP_204_NO_CONTENT,
+        response_class=Response,
         dependencies=[Depends(get_current_superuser)],
     )
     async def delete_user(id: UUID4):


### PR DESCRIPTION
I'm getting an error running the `delete` route. FastAPI apparently chooses JSONResponse by default which encodes `None` as `null`, which means the 204 response has a body, which is an error.

I would think this should be fixed in FastAPI or Starlette, but for now the solution seems to be to return a `Response` directly to ensure FastAPI doesn't use a JSONResponse: https://github.com/tiangolo/fastapi/issues/717#issuecomment-583826657