### PR TITLE
Add dummy `setup.py` that reuses our `setup.cfg`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=2,<3"]
+requires = ["flit_core >=2,<3", "setuptools"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,9 @@
+[metadata]
+name = fastapi-users
+version = attr: fastapi_users.__version__
+
 [bumpversion]
-current_version = 6.1.1
+current_version = attr: fastapi_users.__version__
 commit = True
 tag = True
 
@@ -30,7 +34,7 @@ ignore_missing_imports = True
 
 [tool:pytest]
 addopts = --ignore=test_build.py
-markers = 
+markers =
 	authentication
 	db
 	fastapi_users

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from setuptools import setup
+
+# Reuse our current `setup.cfg` definition for the installation
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
It provides a dummy `setup.py` that reuses our `setup.cfg`.

This will support
- Poetry `my-package = {path = "<PATH>", develop = true}` dependencies
- `pip install -e <PATH>` dependencies

It also defines `setuptools` as a build dependency and extracts the version from `fastapi_users.__version__` to avoid hardcoded duplicates.

Fix #660 